### PR TITLE
Fix Docker build: skip lefthook installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apk add --no-cache git python3 make g++
 
 WORKDIR /app
 
+# Установка переменной окружения для пропуска lefthook в Docker
+ENV DOCKER_BUILD=true
+
 # Копирование файлов конфигурации и зависимостей
 COPY package*.json pnpm-*.yaml ./
 COPY patches ./patches


### PR DESCRIPTION
- Add DOCKER_BUILD=true environment variable to skip git hooks setup
- This prevents prepare.mjs script from failing during Docker build
