### PR TITLE
fix: Add pnpm approve-builds and tsup for extension-sdk build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ COPY scripts ./scripts
 # Установка зависимостей
 RUN pnpm install --frozen-lockfile
 
+# Разрешение выполнения скриптов сборки для зависимостей
+RUN pnpm approve-builds
+
+# Установка tsup глобально для extension-sdk
+RUN pnpm add -g tsup
+
 # Сборка всех пакетов
 RUN pnpm build
 


### PR DESCRIPTION
- Add pnpm approve-builds to allow blocked build scripts
- Install tsup globally for @n8n/extension-sdk build
- Fixes tsup not found error during Docker build
